### PR TITLE
Upstream commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "async": "~0.2.10",
     "gulp-requirejs": "https://github.com/pago/gulp-requirejs/tarball/patch-1"
   },
+  "main": "handlebones.js",
   "scripts": {
     "test": "gulp"
   }


### PR DESCRIPTION
This simply merges in a commit from https://github.com/FormidableLabs/handlebones/commits/master that allow the library to play more nicely with webpack and other loaders.